### PR TITLE
chore: clear eslint warnings and bump Actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Generate .env file
         run: |
           cat .env.example | envsubst > .env
@@ -67,16 +67,16 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           static_site_generator: next
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache
@@ -92,7 +92,7 @@ jobs:
       - name: Generate sitemap
         run: npm run generate-sitemap
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 
@@ -105,4 +105,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/src/components/Career/ContactForm/Form/Form.tsx
+++ b/src/components/Career/ContactForm/Form/Form.tsx
@@ -53,9 +53,13 @@ export const Form = () => {
     },
   });
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    formik.setFieldValue('cv', acceptedFiles[0]);
-  }, []);
+  const { setFieldValue } = formik;
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      setFieldValue('cv', acceptedFiles[0]);
+    },
+    [setFieldValue],
+  );
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     multiple: false,

--- a/src/components/Comparison/ContactForm/Form/Form.tsx
+++ b/src/components/Comparison/ContactForm/Form/Form.tsx
@@ -52,9 +52,13 @@ export const Form = () => {
     },
   });
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    formik.setFieldValue('cv', acceptedFiles[0]);
-  }, []);
+  const { setFieldValue } = formik;
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      setFieldValue('cv', acceptedFiles[0]);
+    },
+    [setFieldValue],
+  );
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     multiple: false,


### PR DESCRIPTION
## Summary
Tail-end cleanup after the deps upgrade in #258.

- **ESLint**: two `react-hooks/exhaustive-deps` warnings in `Career/ContactForm/Form.tsx` and `Comparison/ContactForm/Form.tsx`. Fixed by pulling `setFieldValue` out of formik before the useCallback so the deps array is honest. Behavior unchanged — `setFieldValue` is stable across renders.
- **GitHub Actions**: bumped to versions that ship with Node 24 (deprecation notice in the last deploy run). All major-version bumps but no API/input changes for these actions.
  - `actions/checkout` 4 → 6
  - `actions/setup-node` 4 → 6
  - `actions/cache` 4 → 5
  - `actions/configure-pages` 5 → 6
  - `actions/upload-pages-artifact` 3 → 5
  - `actions/deploy-pages` 4 → 5

## Test plan
- [x] `npm run build` clean (no eslint warnings)
- [ ] First deploy run on main publishes successfully (~2 min)
- [ ] No new annotations in the workflow log